### PR TITLE
deps,chaincheck: Updates chronicle-std to v2.1.0 and adjust chaincheck

### DIFF
--- a/script/chaincheck/IGreenhouseChaincheck.sol
+++ b/script/chaincheck/IGreenhouseChaincheck.sol
@@ -19,6 +19,7 @@ import {IGreenhouse} from "src/IGreenhouse.sol";
  *      {
  *          "IGreenhouse": {},
  *          "IAuth": {
+ *              "disabled": bool,
  *              "legacy": bool,
  *              "authed": [
  *                  "<Ethereum address>",
@@ -26,6 +27,7 @@ import {IGreenhouse} from "src/IGreenhouse.sol";
  *              ]
  *          },
  *          "IToll": {
+ *              "disabled": bool,
  *              "legacy": bool,
  *              "tolled": [
  *                  "<Ethereum address>",


### PR DESCRIPTION
Updates `chronicle-std` to v2.1.0, which added a `disabled` field to the `IAuth` and `IToll` interfaces.