### PR TITLE
ci: pin external GitHub Actions

### DIFF
--- a/.github/workflows/gas.yml
+++ b/.github/workflows/gas.yml
@@ -10,13 +10,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
       - run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,12 +10,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 

--- a/.github/workflows/solc-version-tests.yml
+++ b/.github/workflows/solc-version-tests.yml
@@ -10,13 +10,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
       - run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,13 +10,13 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
       - run: yarn install
 
       - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d
         with:
           version: nightly
 


### PR DESCRIPTION
Pins third-party GitHub Actions `uses:` references to full commit SHAs.

Context: RFC-043 GitHub organization security hardening.

This PR does not change GitHub org settings, branch protection, or workflow permissions.

Pinned references:
- `.github/workflows/gas.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/gas.yml:19` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`
- `.github/workflows/lint.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/lint.yml:18` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`
- `.github/workflows/solc-version-tests.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/solc-version-tests.yml:19` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`
- `.github/workflows/unit-tests.yml:13` `actions/checkout@v3` -> `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744`
- `.github/workflows/unit-tests.yml:19` `foundry-rs/foundry-toolchain@v1` -> `foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d`